### PR TITLE
Add GitHub actions script

### DIFF
--- a/.github/workflows/Release-Linux.yaml
+++ b/.github/workflows/Release-Linux.yaml
@@ -1,0 +1,105 @@
+name: Release-Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag to release'
+        required: true
+        
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [x64, arm64]  # 添加架构
+        
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+    
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Verify Python Version
+        run: python --version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Yarn Version
+        run: corepack prepare yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint code
+        run: |
+          yarn lint || (echo "Linting issues found, trying to fix..." && yarn lint-fix)
+
+      - name: Build the project for x64
+        if: matrix.architecture == 'x64'
+        run: yarn make --arch=x64 --verbose
+
+      - name: Build the project for arm64
+        if: matrix.architecture == 'arm64'
+        run: yarn make --arch=arm64 --verbose
+
+      - name: Find built assets RPM
+        id: find_assets_rpm
+        run: |
+          ASSET_PATH=$(find ./out/make -path './node_modules' -prune -o -name '*.rpm' -print | head -n 1)
+          ABSOLUTE_ASSET_PATH=$(realpath "$ASSET_PATH")
+          echo "ASSET_RPM_PATH=$ABSOLUTE_ASSET_PATH" >> $GITHUB_ENV
+          BASENAME=$(basename "$ASSET_PATH")
+          echo "ASSET_RPM_BASENAME=$BASENAME" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Find built assets DEB
+        id: find_assets_deb
+        run: |
+          ASSET_PATH=$(find ./out/make -path './node_modules' -prune -o -name '*.deb' -print | head -n 1)
+          ABSOLUTE_ASSET_PATH=$(realpath "$ASSET_PATH")
+          echo "ASSET_DEB_PATH=$ABSOLUTE_ASSET_PATH" >> $GITHUB_ENV
+          BASENAME=$(basename "$ASSET_PATH")
+          echo "ASSET_DEB_BASENAME=$BASENAME" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Upload Artifacts RPM
+        id: upload-artifact-rpm
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_RPM_BASENAME }}
+          path: ${{ env.ASSET_RPM_PATH }}
+          overwrite: true
+
+      - name: Upload Artifacts DEB
+        id: upload-artifact-deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_DEB_BASENAME }}
+          path: ${{ env.ASSET_DEB_PATH }}
+          overwrite: true
+
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.tag_name }}
+          name: ${{ env.ASSET_RPM_BASENAME }}
+          files: ${{ env.ASSET_RPM_PATH }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.tag_name }}
+          name: ${{ env.ASSET_DEB_BASENAME }}
+          files: ${{ env.ASSET_DEB_PATH }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Release-Macos.yaml
+++ b/.github/workflows/Release-Macos.yaml
@@ -1,0 +1,78 @@
+name: Release-Macos
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag to release'
+        required: true
+
+jobs:
+  release:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        architecture: [x64, arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Verify Python Version
+        run: python --version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Yarn Version
+        run: corepack prepare yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint code
+        run: |
+          yarn lint || (echo "Linting issues found, trying to fix..." && yarn lint-fix)
+
+      - name: Build the project for x64
+        if: matrix.architecture == 'x64'
+        run: yarn make --arch=x64 --verbose
+
+      - name: Build the project for arm64
+        if: matrix.architecture == 'arm64'
+        run: yarn make --arch=arm64 --verbose
+
+      - name: Find built asset on macOS
+        id: find_asset
+        run: |
+          ASSET_PATH=$(find ./out/make -path './node_modules' -prune -o -name '*.dmg' -print | head -n 1)
+          ABSOLUTE_ASSET_PATH=$(realpath "$ASSET_PATH")
+          echo "ASSET_PATH=$ABSOLUTE_ASSET_PATH" >> $GITHUB_ENV
+          BASENAME=$(basename "$ASSET_PATH")
+          echo "ASSET_BASENAME=$BASENAME" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_BASENAME }}
+          path: ${{ env.ASSET_PATH }}
+          overwrite: true
+
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.tag_name }}
+          name: ${{ env.ASSET_BASENAME }}
+          files: ${{ env.ASSET_PATH }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Release-Windows.yaml
+++ b/.github/workflows/Release-Windows.yaml
@@ -1,0 +1,131 @@
+name: Release-Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag to release'
+        required: true
+
+
+jobs:
+  release:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [x64, arm64, i386]  # Add architecture
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Verify Python Version
+        run: python --version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Yarn Version
+        run: corepack prepare yarn
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          $retries = 5
+          $count = 0
+          do {
+            yarn install
+            $exitCode = $?
+            if ($exitCode -eq 0) {
+              break
+            }
+            $count++
+            Write-Output "Retrying ($count/$retries)..."
+            Start-Sleep -Seconds 10
+          } while ($count -lt $retries)
+
+      - name: Lint code
+        run: |
+          yarn lint || (echo "Linting issues found, trying to fix..." && yarn lint-fix)
+
+      - name: Build the project for x64
+        if: matrix.architecture == 'x64'
+        run: yarn make --arch=x64 --verbose
+
+      - name: Build the project for arm64
+        if: matrix.architecture == 'arm64'
+        run: yarn make --arch=arm64 --verbose
+
+      - name: Build the project for arm64
+        if: matrix.architecture == 'i386'
+        run: yarn make --arch=ia32 --verbose
+
+      - name: Find built asset on Windows arm64
+        if: matrix.architecture == 'arm64'
+        id: find_asset_arm64
+        run: |
+          $assetPath = (Get-ChildItem -Path out/make -Recurse -Filter *.exe | Select-Object -First 1).FullName
+          $basename = [System.IO.Path]::GetFileNameWithoutExtension($assetPath)
+          $extension = [System.IO.Path]::GetExtension($assetPath)
+          $newBasename = ($basename -replace ' ', '-') + "-arm64" + $extension
+          $newFilePath = (Join-Path -Path (Get-Item $assetPath).DirectoryName -ChildPath $newBasename)
+          Rename-Item -Path $assetPath -NewName $newBasename
+          $escapedFilePath = $newFilePath -replace '\\', '\\\\'
+          echo "ASSET_BASENAME=$newBasename" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "ASSET_PATH=$escapedFilePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Find built asset on Windows x64
+        if: matrix.architecture == 'x64'
+        id: find_asset_x64
+        run: |
+          $assetPath = (Get-ChildItem -Path out/make -Recurse -Filter *.exe | Select-Object -First 1).FullName
+          $basename = [System.IO.Path]::GetFileNameWithoutExtension($assetPath)
+          $extension = [System.IO.Path]::GetExtension($assetPath)
+          $newBasename = ($basename -replace ' ', '-') + "-x64" + $extension
+          $newFilePath = (Join-Path -Path (Get-Item $assetPath).DirectoryName -ChildPath $newBasename)
+          Rename-Item -Path $assetPath -NewName $newBasename
+          $escapedFilePath = $newFilePath -replace '\\', '\\\\'
+          echo "ASSET_BASENAME=$newBasename" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "ASSET_PATH=$escapedFilePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Find built asset on Windows x86
+        if: matrix.architecture == 'i386'
+        id: find_asset_x86
+        run: |
+          $assetPath = (Get-ChildItem -Path out/make -Recurse -Filter *.exe | Select-Object -First 1).FullName
+          $basename = [System.IO.Path]::GetFileNameWithoutExtension($assetPath)
+          $extension = [System.IO.Path]::GetExtension($assetPath)
+          $newBasename = ($basename -replace ' ', '-') + "-x86" + $extension
+          $newFilePath = (Join-Path -Path (Get-Item $assetPath).DirectoryName -ChildPath $newBasename)
+          Rename-Item -Path $assetPath -NewName $newBasename
+          $escapedFilePath = $newFilePath -replace '\\', '\\\\'
+          echo "ASSET_BASENAME=$newBasename" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "ASSET_PATH=$escapedFilePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_BASENAME }}
+          path: ${{ env.ASSET_PATH }}
+          overwrite: true
+
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.tag_name }}
+          name: ${{ env.ASSET_BASENAME }}
+          files: ${{ env.ASSET_PATH }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/forge.config.js
+++ b/forge.config.js
@@ -3,6 +3,7 @@ module.exports = {
     asar: true,
     appBundleId: "io.github.pd4d10.debugtron",
     icon: "assets/icon",
+    executableName: "debugtron"
   },
   makers: [
     { name: "@electron-forge/maker-squirrel", config: {} },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,5 @@
     "universal-analytics": "^0.5.3",
     "vite": "^5.2.11"
   },
-  "packageManager": "yarn@4.1.0+sha256.81a00df816059803e6b5148acf03ce313cad36b7f6e5af6efa040a15981a6ffb",
   "productName": "Debugtron"
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "registry-js": "^1.16.0",
     "simple-plist": "^1.3.1",
+    "electron-redux": "2.0.0-alpha.9",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -50,7 +51,6 @@
     "@types/uuid": "^9.0.8",
     "electron": "^30.0.2",
     "electron-devtools-installer": "^3.2.0",
-    "electron-redux": "2.0.0-alpha.9",
     "electron-update-notification": "^0.1.0",
     "get-port": "^7.1.0",
     "ini": "^4.1.2",


### PR DESCRIPTION
# Add Github Actions script

* Need to manually run the script, specify the version number tag when running, and run the scripts for macOS, Windows, and Linux once.

> Run Actions And Set Tag
<img width="1511" alt="image" src="https://github.com/pd4d10/debugtron/assets/19379443/a3eb66a0-d3f0-448d-9f98-9079dd7e6c25">

> Runing
<img width="1511" alt="image" src="https://github.com/pd4d10/debugtron/assets/19379443/fb5b4359-d020-495e-9d07-14b646af5835">

* After successful running, the corresponding version will be synchronized and released in the "release" section, and the corresponding build files can also be found in Github Artifacts.

> Github Release
<img width="1296" alt="image" src="https://github.com/pd4d10/debugtron/assets/19379443/60c048d7-bc7f-40f9-a1c7-4fb4c3a97c33">


> Github Artifacts 
<img width="1508" alt="image" src="https://github.com/pd4d10/debugtron/assets/19379443/1ac811f5-07f2-4947-8776-376681961d73">

