### PR TITLE
Add-Auto-Run-Github-Actions

### DIFF
--- a/.github/workflows/Release-Linux.yaml
+++ b/.github/workflows/Release-Linux.yaml
@@ -1,6 +1,9 @@
 name: Release-Linux
 
 on:
+  push:
+    tags:
+      - "v*.*.*" # 监听所有以 'v' 开头的标签
   workflow_dispatch:
     inputs:
       tag_name:
@@ -91,15 +94,15 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.event.inputs.tag_name }}
-          name: ${{ env.ASSET_RPM_BASENAME }}
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: ${{ env.ASSET_RPM_PATH }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.event.inputs.tag_name }}
-          name: ${{ env.ASSET_DEB_BASENAME }}
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: ${{ env.ASSET_DEB_PATH }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Release-Macos.yaml
+++ b/.github/workflows/Release-Macos.yaml
@@ -1,6 +1,9 @@
 name: Release-Macos
 
 on:
+  push:
+    tags:
+      - "v*.*.*" # 监听所有以 'v' 开头的标签
   workflow_dispatch:
     inputs:
       tag_name:
@@ -72,7 +75,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.event.inputs.tag_name }}
-          name: ${{ env.ASSET_BASENAME }}
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: ${{ env.ASSET_PATH }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Release-Windows.yaml
+++ b/.github/workflows/Release-Windows.yaml
@@ -1,6 +1,9 @@
 name: Release-Windows
 
 on:
+  push:
+    tags:
+      - "v*.*.*" # 监听所有以 'v' 开头的标签
   workflow_dispatch:
     inputs:
       tag_name:
@@ -40,7 +43,7 @@ jobs:
       - name: Install dependencies
         shell: pwsh
         run: |
-          $retries = 5
+          $retries = 1
           $count = 0
           do {
             yarn install
@@ -50,12 +53,12 @@ jobs:
             }
             $count++
             Write-Output "Retrying ($count/$retries)..."
-            Start-Sleep -Seconds 10
+            Start-Sleep -Seconds 5
           } while ($count -lt $retries)
 
-      - name: Lint code
-        run: |
-          yarn lint || (echo "Linting issues found, trying to fix..." && yarn lint-fix)
+      # - name: Lint code
+      #   run: |
+      #     yarn lint || (echo "Linting issues found, trying to fix..." && yarn lint-fix)
 
       - name: Build the project for x64
         if: matrix.architecture == 'x64'
@@ -124,7 +127,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.event.inputs.tag_name }}
-          name: ${{ env.ASSET_BASENAME }}
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: ${{ env.ASSET_PATH }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "universal-analytics": "^0.5.3",
     "vite": "^5.2.11"
   },
-  "packageManager": "yarn@4.3.1+sha512.af78262d7d125afbfeed740602ace8c5e4405cd7f4735c08feb327286b2fdb2390fbca01589bfd1f50b1240548b74806767f5a063c94b67e431aabd0d86f7774",
+  "packageManager": "yarn@1.22.22",
   "productName": "Debugtron"
 }


### PR DESCRIPTION
# Add Auto Run Github Actions

* Now, you can create a new release version on the Github Release page, and Actions will automatically build project files and publish them to the Release page.

## There are problems.

* Please pay attention to several issues. The version set by `packageManager` in `package.json` is problematic, which will cause Python linking errors when building in Linux and macOS environments. Please be sure to update the version of `packageManager`.

<img width="862" alt="iShot_2024-07-12_11 13 33" src="https://github.com/user-attachments/assets/85db1b65-9f73-46cd-b1f2-a93153bddaa5">

![1720754070246](https://github.com/user-attachments/assets/e0ee7d70-bae0-46c4-b317-6e8c63995277)

* There are also problems with the `"lint": "prettier --ignore-unknown --check '**/*'",` and `"lint-fix": "prettier --ignore-unknown --write '**/*'",` in `package.json`. In the Windows system, `**/*` is incorrect and cannot match any files, which will cause problems with the Windows build.

* To solve this problem, I have disabled `yarn lint` in `Release-Windows.yaml`.

* If this problem is fixed in the future, you can uncomment `Release-Windows.yaml`.

<img width="949" alt="image" src="https://github.com/user-attachments/assets/0995f269-c709-454b-a021-1e82386be95d">


## Build Steps

* create release

<img width="941" alt="iShot_2024-07-12_11 12 49" src="https://github.com/user-attachments/assets/30ad9328-7a37-41a9-a167-38961800de25">

* Wait for actions to complete.

<img width="1511" alt="iShot_2024-07-12_11 13 03" src="https://github.com/user-attachments/assets/6b4f0b01-a6d0-44be-8be5-a60301765b85">

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/5482e8bf-784f-40a2-8ed1-52e3e97a879c">

* Confirm that all versions have been released.

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/c415238f-1252-4b1c-b25d-9ba1b50c29e0">
